### PR TITLE
Add the blame keyword for improved findability

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "commands": [
       {
         "command": "annotator.annotate",
-        "title": "Annotate the Current File or the File Before the Commit (if on Commit Diff)",
+        "title": "Annotate (Blame) the Current File or the File Before the Commit (if on Commit Diff)",
         "category": "Annotator"
       },
       {


### PR DESCRIPTION
This closes issue #37

As described there:

>I don't often have a need for a tool like Annotator, but when I do, it's really useful. However, due to the time gap between invocations, I'm unlikely to remember that it uses the word "annotate" in the command palette. The usual term I use (as used by several VCS programs, Github, etc.) is "blame." If I'm searching for the tool, I'm likely to type blame and be unable to find this plugin.
>
>I would love to be able to find this plugin's features by typing blame.